### PR TITLE
Fix loading state on failed fetch

### DIFF
--- a/src/utils/fetchStydy.ts
+++ b/src/utils/fetchStydy.ts
@@ -11,6 +11,7 @@ export const fetchStudy = async (props: FetchDataType) => {
   setLoading(true);
   const fetchData: StudyRecordType[] = await selectStudyRecord();
   if (fetchData === null) {
+    setLoading(false);
     return;
   }
   // console.log(Array.isArray(fetchData));


### PR DESCRIPTION
## Summary
- fix fetchStudy so loading state is cleared when API call fails

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find type definition file for 'aria-query', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684023490108833383a018af90a5e638